### PR TITLE
Replug the "Latest Posts" hook to display Anime.

### DIFF
--- a/public/wp-content/themes/newsup-child/functions.php
+++ b/public/wp-content/themes/newsup-child/functions.php
@@ -23,7 +23,7 @@
             'edit_published_posts' => true,
             'publish_posts' => true,
             'read' => true,
-            'upload_files' => true  
+            'upload_files' => true
         ) );
         add_role( 'animeEditor', 'Anime Editor', array(
             'delete_others_pages' => true,
@@ -50,6 +50,82 @@
             'read' => true,
             'read_private_pages' => true,
             'read_private_posts' => true,
-            'upload_files' => true    
+            'upload_files' => true
         ) );
     }
+
+// These functions below override existing hooks in
+// the parent theme. These functions specifically
+// deal with injected HTML/PHP code for the use of
+// content sections such as the Homepage Banner, and
+// other advanced content blocks.
+//
+// NOTE:  CHILD THEMES LOAD BEFORE PARENT THEMES AND
+//        THUS CAN OVERRIDE THEIR FUNCTIONS. THIS IS
+//        CALLED REPLUGGING A HOOK FROM THE PARENT.
+//
+// This function is called whenever the theme requests
+// the content section for the banner of trending posts
+// on the homepage. This function is originall located
+// in ../newsup/inc/hooks/hooks.php and has been copied
+// here to be overriden.
+if (!function_exists('newsup_banner_trending_posts')):
+    /**
+     *
+     * @since newsup 1.0.0
+     *
+     */
+    function newsup_banner_exclusive_posts()  {
+            if (is_front_page() || is_home()) {
+                $show_flash_news_section = newsup_get_option('show_flash_news_section');
+            if ($show_flash_news_section):
+        ?>
+            <section class="mg-latest-news-sec">
+                <?php
+                $category = newsup_get_option('select_flash_news_category');
+                $number_of_posts = newsup_get_option('number_of_flash_news');
+                $newsup_ticker_news_title = newsup_get_option('flash_news_title');
+
+                $all_posts = newsup_get_posts($number_of_posts, $category);
+                $show_trending = true;
+                $count = 1;
+
+                // This code will provide a query on Custom Post Type: Anime
+                // to be used by this module. Modifications were made to use
+                // the custom query instead of the original $all_posts obejct.
+                $anime_posts = new WP_Query(array('post_type' => 'anime', 'orderby' => 'date'));
+                ?>
+                <div class="container-fluid">
+                    <div class="mg-latest-news">
+                         <div class="bn_title">
+                            <h2>
+                                <?php if (!empty($newsup_ticker_news_title)): ?>
+                                    <?php echo esc_html($newsup_ticker_news_title); ?><span></span>
+                                <?php endif; ?>
+                            </h2>
+                        </div>
+                        <div class="mg-latest-news-slider marquee">
+                            <?php
+                            if ($anime_posts->have_posts()) :
+                                while ($anime_posts->have_posts()) : $anime_posts->the_post();
+                                    ?>
+                                    <a href="<?php the_permalink(); ?>">
+                                        <span><?php the_title(); ?></span>
+                                     </a>
+                                    <?php
+                                    $count++;
+                                endwhile;
+                                endif;
+                                wp_reset_postdata();
+                                ?>
+                        </div>
+                    </div>
+                </div>
+            </section>
+            <!-- Excluive line END -->
+        <?php endif;
+         }
+    }
+endif;
+
+?>

--- a/public/wp-content/themes/newsup/inc/ansar/hooks/hooks.php
+++ b/public/wp-content/themes/newsup/inc/ansar/hooks/hooks.php
@@ -1,19 +1,19 @@
-<?php 
+<?php
 /**
 PHP functions & Hooks:
-Theme URL: https://wordpress.org/themes/newsphere/, 
+Theme URL: https://wordpress.org/themes/newsphere/,
 http://afthemes.com/, (C) 2020 AF Themes, GPLv2
 */
-if (!function_exists('newsup_banner_trending_posts')):
+if (!function_exists('newsup_banner_exclusive_posts')):
     /**
      *
      * @since newsup 1.0.0
      *
      */
-    function newsup_banner_exclusive_posts()  { 
+    function newsup_banner_exclusive_posts()  {
             if (is_front_page() || is_home()) {
                 $show_flash_news_section = newsup_get_option('show_flash_news_section');
-            if ($show_flash_news_section): 
+            if ($show_flash_news_section):
         ?>
             <section class="mg-latest-news-sec">
                 <?php
@@ -69,7 +69,7 @@ if (!function_exists('newsup_banner_tabbed_posts')):
      */
     function newsup_banner_tabbed_posts()
     {
-        
+
             $show_excerpt = 'false';
             $excerpt_length = '20';
             $number_of_posts = '4';
@@ -166,7 +166,7 @@ if (!function_exists('newsup_banner_advertisement')):
                             <?php echo $newsup_banner_advertisement; ?>
                         </a>
                     </div>
-                <?php endif; ?>                
+                <?php endif; ?>
 
             </div>
             <!-- Trending line END -->
@@ -177,7 +177,7 @@ if (!function_exists('newsup_banner_advertisement')):
             <div class="mg-ads-area">
                 <?php dynamic_sidebar('home-advertisement-widgets'); ?>
             </div>
-                <?php endif; 
+                <?php endif;
     }
 endif;
 
@@ -287,7 +287,7 @@ if (!function_exists('newsup_front_page_banner_section')) :
         $select_vertical_slider_news_category = newsup_get_option('select_vertical_slider_news_category');
         $vertical_slider_number_of_slides = newsup_get_option('vertical_slider_number_of_slides');
         $all_posts_vertical = newsup_get_posts($vertical_slider_number_of_slides, $select_vertical_slider_news_category);
-        if ($newsup_enable_main_slider):  
+        if ($newsup_enable_main_slider):
 
             $main_banner_section_background_image = newsup_get_option('main_banner_section_background_image');
             $main_banner_section_background_image_url = wp_get_attachment_image_src($main_banner_section_background_image, 'full');
@@ -301,11 +301,11 @@ if (!function_exists('newsup_front_page_banner_section')) :
                     <div class="">
                         <div class="col-md-8">
                             <div class="row">
-                                <div id="homemain"class="homemain owl-carousel mr-bot60 pd-r-10"> 
+                                <div id="homemain"class="homemain owl-carousel mr-bot60 pd-r-10">
                                 <?php newsup_get_block('list', 'banner'); ?>
                                 </div>
                             </div>
-                        </div> 
+                        </div>
                         <?php do_action('newsup_action_banner_tabbed_posts');?>
                     </div>
                 </div>
@@ -318,4 +318,3 @@ if (!function_exists('newsup_front_page_banner_section')) :
     }
 endif;
 add_action('newsup_action_front_page_main_section_1', 'newsup_front_page_banner_section', 40);
-


### PR DESCRIPTION
Resolves #33 

This theme is made in a way where content sections are called by using hooks (this is because all the content sections are made into widgets to be used by non-devs on the Admin panel of WP). This is not necessarily a problem as we can still override the hook, and override the provided query internally. 