### PR TITLE
Replug Newsup "Tabbed Post" content.

### DIFF
--- a/public/wp-content/themes/newsup-child/functions.php
+++ b/public/wp-content/themes/newsup-child/functions.php
@@ -56,4 +56,191 @@ function set_custom_roles(){
     ) );
 }
 
+if (!function_exists('newsup_get_terms')):
+function newsup_get_terms( $category_id = 0, $taxonomy='category', $default='' ){
+    $taxonomy = !empty($taxonomy) ? $taxonomy : 'category';
+
+    if ( $category_id > 0 ) {
+            $term = get_term_by('id', absint($category_id), $taxonomy );
+            if($term)
+                return esc_html($term->name);
+
+
+    } else {
+        $terms = get_terms(array(
+            'taxonomy' => $taxonomy,
+            'orderby' => 'name',
+            'order' => 'ASC',
+            'hide_empty' => true,
+        ));
+
+
+        if (isset($terms) && !empty($terms)) {
+            foreach ($terms as $term) {
+                if( $default != 'first' ){
+                    $array['0'] = __('Select Category', 'newsup');
+                }
+                $array[$term->term_id] = esc_html($term->name);
+            }
+
+            return $array;
+        }
+    }
+}
+endif;
+
+/**
+ * Returns all categories.
+ *
+ * @since newsup 1.0.0
+ */
+if (!function_exists('newsup_get_terms_link')):
+function newsup_get_terms_link( $category_id = 0 ){
+
+    if (absint($category_id) > 0) {
+        return get_term_link(absint($category_id), 'category');
+    } else {
+        return get_post_type_archive_link('post');
+    }
+}
+endif;
+
+/**
+ * Returns word count of the sentences.
+ *
+ * @since newsup 1.0.0
+ */
+if (!function_exists('newsup_get_excerpt')):
+    function newsup_get_excerpt($length = 25, $newsup_content = null, $post_id = 1) {
+        $widget_excerpt   = newsup_get_option('global_widget_excerpt_setting');
+        if($widget_excerpt == 'default-excerpt'){
+            return the_excerpt();
+        }
+
+        $length          = absint($length);
+        $source_content  = preg_replace('`\[[^\]]*\]`', '', $newsup_content);
+        $trimmed_content = wp_trim_words($source_content, $length, '...');
+        return $trimmed_content;
+    }
+endif;
+
+/**
+ * Returns no image url.
+ *
+ * @since newsup 1.0.0
+ */
+if(!function_exists('newsup_no_image_url')):
+    function newsup_no_image_url(){
+        $url = get_template_directory_uri().'/assets/images/no-image.png';
+        return $url;
+    }
+
+endif;
+
+
+
+
+
+/**
+ * Outputs the tab posts
+ *
+ * @since 1.0.0
+ *
+ * @param array $args  Post Arguments.
+ */
+if (!function_exists('newsup_render_posts')):
+  function newsup_render_posts( $type, $show_excerpt, $excerpt_length, $number_of_posts, $category = '0' ){
+
+    $args = array();
+
+    switch ($type) {
+        case 'popular':
+            $args = array(
+                'post_type' => 'anime',
+                'post_status' => 'publish',
+                'posts_per_page' => absint($number_of_posts),
+                'orderby' => 'comment_count',
+                'ignore_sticky_posts' => true
+            );
+            break;
+
+        case 'recent':
+            $args = array(
+                'post_type' => 'anime',
+                'post_status' => 'publish',
+                'posts_per_page' => absint($number_of_posts),
+                'orderby' => 'date',
+                'ignore_sticky_posts' => true
+            );
+            break;
+
+        case 'categorised':
+            $args = array(
+                'post_type' => 'genre',
+                'post_status' => 'publish',
+                'posts_per_page' => absint($number_of_posts),
+                'ignore_sticky_posts' => true
+            );
+            $category = isset($category) ? $category : '0';
+            if (absint($category) > 0) {
+                $args['cat'] = absint($category);
+            }
+            break;
+
+
+        default:
+            break;
+    }
+
+    if( !empty($args) && is_array($args) ){
+        $all_posts = new WP_Query($args);
+        if($all_posts->have_posts()):
+            echo '<div class="mg-posts-sec mg-posts-modul-2"><div class="mg-posts-sec-inner row"><div class="small-list-post col-lg-12"><ul>';
+            while($all_posts->have_posts()): $all_posts->the_post();
+
+                ?>
+
+                  <li class="small-post clearfix">
+                        <?php
+                        if(has_post_thumbnail()){
+                            $thumb = wp_get_attachment_image_src(get_post_thumbnail_id(get_the_ID()));
+                            $url = $thumb['0'];
+                            $col_class = 'col-sm-8';
+                        }else {
+                            $url = '';
+                            $col_class = 'col-sm-12';
+                        }
+                        global $post;
+                        ?>
+                        <?php if (!empty($url)): ?>
+                           <div class="img-small-post">
+                                <img src="<?php echo esc_url($url); ?>"/>
+                            </div>
+                        <?php endif; ?>
+                        <div class="small-post-content">
+                                <div class="mg-blog-category">
+                                   <?php newsup_post_categories('/'); ?>
+                                </div>
+                                 <div class="title_small_post">
+
+                                    <a href="<?php the_permalink(); ?>">
+                                        <h5>
+                                        <?php the_title(); ?>
+                                        </h5>
+                                    </a>
+
+                                </div>
+                        </div>
+                </li>
+            <?php
+            endwhile;wp_reset_postdata();
+            echo '</ul></div></div></div>';
+        endif;
+    }
+}
+endif;
+
+
+
+
 ?>


### PR DESCRIPTION
This modifies the hook definition within the Newsup parent theme within the child's `functions.php` this particular component was exceptionally deep, so I just took the easy way out.

Production changes: 
- [ ] "Trending Post" tab title to be changed to "Genres" in WP Admin backend.